### PR TITLE
[feature] Customize default config for plugin initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ import Simplert from 'vue2-simplert-plugin'
 Vue.use(Simplert)
 ```
 
+Or, with customize default config which still can be overrided.
+```javascript
+import Simplert from 'vue2-simplert-plugin'
+Vue.use(Simplert, {
+  title: 'test', //string -- title alert
+  message: 'message', //string -- message alert
+  type: 'success', //string -- type : info (default), success, warning, error
+  customClass: '', //string -- custom class in simplert div
+  customIconUrl: '', //string -- custom url custom image icon
+  customCloseBtnText: '', //string -- close button text
+  customCloseBtnClass: '', //string -- custom class for close button
+  onClose: this.onClose, //function -- when close triggered
+  useConfirmBtn: false, //boolean -- using confirm button
+  customConfirmBtnText: '', //string -- confirm button text
+  customConfirmBtnClass: '', //string -- custom class for confirm button
+  onConfirm: this.onConfirm, //function -- when confirm button triggered
+  disableOverlayClick: false, //boolean -- set to true if you want disable overlay click function
+  hideAllButton: false, //boolean -- set to true if you want hide all button
+  onOpen: null, //function -- when simplert open will fire this method if available
+  showXclose: true //boolean -- show x close button
+})
+```
+for more [Methods and Props](https://mazipan.gitbooks.io/vue2-simplert/method-and-props.html)
+
 #### Add template in your root Vue
 
 Usually `App.vue`

--- a/src/simplert-plugin.js
+++ b/src/simplert-plugin.js
@@ -2,18 +2,22 @@ import SimplertComponent from './Simplert.vue'
 import { SimplertEventBus } from './simplert-event-bus.js'
 
 const Simplert = {
-  install (Vue = {}) {
+  install (Vue = {}, options = {}) {
 
     let SimplertPlugin = {
       $vm: null,
       state: {},
-      init(vm) {
+      data: {
+        options: {}
+      },
+      init(vm, opts) {
         this.$vm = vm
+        this.options = opts;
       },
       open(obj) {
         if (!this.$vm) return
         obj.show = true
-        this.$vm.$emit('open', obj);
+        this.$vm.$emit('open', Object.assign({}, this.options, obj));
       },
       close() {
         if (!this.$vm) return
@@ -21,7 +25,7 @@ const Simplert = {
       }
     }
 
-    SimplertPlugin.init(SimplertEventBus)
+    SimplertPlugin.init(SimplertEventBus, options)
 
     Vue.component('simplert', SimplertComponent)
     Vue.prototype.$Simplert = SimplertPlugin

--- a/src/simplert-plugin.js
+++ b/src/simplert-plugin.js
@@ -1,11 +1,8 @@
-import configDefaultConfig from 'vue2-simplert-core/simplert-config'
-
 import SimplertComponent from './Simplert.vue'
 import { SimplertEventBus } from './simplert-event-bus.js'
 
 const Simplert = {
   install (Vue = {}) {
-    const simplertOptions = configDefaultConfig.config
 
     let SimplertPlugin = {
       $vm: null,
@@ -24,11 +21,7 @@ const Simplert = {
       }
     }
 
-    const SimplertInstance = new Vue({
-      data: {
-        simplertOptions
-      }
-    })
+    const SimplertInstance = new Vue();
     SimplertPlugin.init(SimplertInstance)
 
     Vue.component('simplert', SimplertComponent)

--- a/src/simplert-plugin.js
+++ b/src/simplert-plugin.js
@@ -13,16 +13,15 @@ const Simplert = {
       open(obj) {
         if (!this.$vm) return
         obj.show = true
-        SimplertEventBus.$emit('open', obj);
+        this.$vm.$emit('open', obj);
       },
       close() {
         if (!this.$vm) return
-        SimplertEventBus.$emit('close');
+        this.$vm.$emit('close');
       }
     }
 
-    const SimplertInstance = new Vue();
-    SimplertPlugin.init(SimplertInstance)
+    SimplertPlugin.init(SimplertEventBus)
 
     Vue.component('simplert', SimplertComponent)
     Vue.prototype.$Simplert = SimplertPlugin


### PR DESCRIPTION
**Feature**
user can define default config by them self which is no longer being restricted by `vue2-simplert-core/simplert-config` which user can't modify.

For example, we can use some customize default config. Then we don't write the same thing every time we call the simplert to open.
```js
Vue.use(Simplert, {
  customConfirmBtnText: 'Accept',
  customCloseBtnText: 'Reject',
})
```
at https://github.com/mazipan/vue2-simplert-plugin/pull/12/commits/79700b088c9818be05037cf8eda4e66437e75d49


**Code Adjustment**
1. `simplertOptions` is redundancy due to default config is defined in [vue2-simplert-core/ simplert.js](https://github.com/mazipan/vue2-simplert-core/blob/master/simplert.js) which is in [vue2-simplert-plugin/Simplert.vue](https://github.com/mazipan/vue2-simplert-plugin/blob/master/src/Simplert.vue)  (adjusted at https://github.com/mazipan/vue2-simplert-plugin/commit/f678e2dcbf83931f00c861f19ea3117a54d8919f)

https://github.com/mazipan/vue2-simplert-plugin/blob/dedba6dd35bd0cd10714be5f020f284549c13ced/src/simplert-plugin.js#L27-L35

2. `SimplertPlugin` is a set of event bus functions essentially. so I remain the init function providing a interface to bind a existing vue instance `SimplertEventBus` .
adjusted at https://github.com/mazipan/vue2-simplert-plugin/commit/3c8a22254c6e119a744aa6db4f0a24d8d870e3f5